### PR TITLE
Workaround for Mono bug 

### DIFF
--- a/JsonRpc.Commons/Contracts/JsonRpcContractResolver.cs
+++ b/JsonRpc.Commons/Contracts/JsonRpcContractResolver.cs
@@ -141,7 +141,7 @@ namespace JsonRpc.Contracts
                 throw new NotSupportedException("Argument with out, ref, or of pointer type is not supported.");
             // parameter.Name == null for return parameter
             var taskResultType = Utility.GetTaskResultType(parameter.ParameterType);
-            if (parameter.Name != null && taskResultType != null)
+            if (String.IsNullOrWhiteSpace(parameter.Name) != true && taskResultType != null)
                 throw new NotSupportedException("Argument with type of System.Threading.Task is not supported.");
             var attr = parameter.GetCustomAttribute<JsonRpcParameterAttribute>();
             var inst = new JsonRpcParameter


### PR DESCRIPTION
where ParameterInfo returns an empty string in case of return argument.

I know this is "not your fault", but Mono returns an empty string `""` when the `ParameterInfo` object is the return value, which makes your library firing an exception incorrectly...

If you accept this change I could use your lib still from your official distribution, otherwise I'll have to keep a forked version, with packages and stuffs.. :(
The bug will be reported to mono team, but it's gonna take some time before the fix is released.

Thanks