### PR TITLE
Fix GetCustomAttribute that shouldn't be called on a return parameter

### DIFF
--- a/JsonRpc.Commons/Contracts/JsonRpcContractResolver.cs
+++ b/JsonRpc.Commons/Contracts/JsonRpcContractResolver.cs
@@ -143,7 +143,7 @@ namespace JsonRpc.Contracts
             var taskResultType = Utility.GetTaskResultType(parameter.ParameterType);
             if (String.IsNullOrWhiteSpace(parameter.Name) != true && taskResultType != null)
                 throw new NotSupportedException("Argument with type of System.Threading.Task is not supported.");
-            var attr = parameter.GetCustomAttribute<JsonRpcParameterAttribute>();
+            var attr = parameter.IsRetval==false ? parameter.GetCustomAttribute<JsonRpcParameterAttribute>() : null;
             var inst = new JsonRpcParameter
             {
                 IsOptional = attr?.IsOptional ?? parameter.IsOptional,


### PR DESCRIPTION
Another thing that make the lib crashing under mono.
Apparently .net framework/core is more permissive than what the doc is saying, because this method shouldn't be called on return parameter, .net fw/core is just returning `null`, but mono is crashing instead of throwing an exception... lol...
Anyway, this small fix makes everyone happy, specially me! :)